### PR TITLE
Remove hardcoded path to ~/projects/dotfiles/

### DIFF
--- a/configs/git/.gitconfig
+++ b/configs/git/.gitconfig
@@ -183,6 +183,9 @@
     name = Piotr Kowalski
 
 # Include private configuration
+# Kept at a fixed path: git does not expand env vars in include.path, and the
+# private repo lives outside this one (no symlink to resolve relative to).
+# A missing file here is silently ignored, so this is safe on other machines.
 [include]
     path = ~/projects-private/dotfiles-private/.gitconfig
 

--- a/configs/git/.gitconfig
+++ b/configs/git/.gitconfig
@@ -187,7 +187,8 @@
     path = ~/projects-private/dotfiles-private/.gitconfig
 
 # Include platform-specific configuration
+# Paths are relative to this file's real location, so the repo works wherever it is cloned.
 [include]
-    # path = ~/projects/dotfiles/configs/git/.gitconfig-linux
-    path = ~/projects/dotfiles/configs/git/.gitconfig-macos
-    # path = ~/projects/dotfiles/configs/git/.gitconfig-windows
+    # path = ./.gitconfig-linux
+    path = ./.gitconfig-macos
+    # path = ./.gitconfig-windows

--- a/configs/shells/__aliases.sh
+++ b/configs/shells/__aliases.sh
@@ -58,7 +58,7 @@ alias ......='cd ../../../../..'
 ### Aliases for project directories
 alias pro='cd ~/projects/'
 alias tmp='cd ~/projects/tmp/'
-alias dotfiles='cd ~/projects/dotfiles/'
+alias dotfiles='cd "$DOTFILES_DIR"'
 alias dotfiles-private='cd ~/projects-private/dotfiles-private/'
 
 # ------------------------------------------------------------------------------

--- a/configs/shells/__aliases.sh
+++ b/configs/shells/__aliases.sh
@@ -59,7 +59,7 @@ alias ......='cd ../../../../..'
 alias pro='cd ~/projects/'
 alias tmp='cd ~/projects/tmp/'
 alias dotfiles='cd "$DOTFILES_DIR"'
-alias dotfiles-private='cd ~/projects-private/dotfiles-private/'
+alias dotfiles-private='cd "$DOTFILES_PRIVATE_DIR"'
 
 # ------------------------------------------------------------------------------
 

--- a/configs/shells/__variables.sh
+++ b/configs/shells/__variables.sh
@@ -49,7 +49,7 @@ fi
 export PYTHON=$(command -v python3)
 
 ### Support ripgrep
-export RIPGREP_CONFIG_PATH="$HOME/projects/dotfiles/configs/.ripgreprc"
+export RIPGREP_CONFIG_PATH="$DOTFILES_DIR/configs/.ripgreprc"
 
 ### Increase default memory for Node.js processes
 export NODE_OPTIONS=--max_old_space_size=4096

--- a/configs/shells/bash/.bash_profile
+++ b/configs/shells/bash/.bash_profile
@@ -1,25 +1,28 @@
 #!/usr/bin/env bash
 
+### Resolve the dotfiles repo root from this file's real location (handles symlinks)
+export DOTFILES_DIR="$(cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../../.." && pwd)"
+
 ### Load file with variables
-source ~/projects/dotfiles/configs/shells/__variables.sh
+source "$DOTFILES_DIR/configs/shells/__variables.sh"
 
 ### Load file with aliases
-source ~/projects/dotfiles/configs/shells/__aliases.sh
+source "$DOTFILES_DIR/configs/shells/__aliases.sh"
 
 ### Load prompt definition
-source ~/projects/dotfiles/configs/shells/bash/.prompt
+source "$DOTFILES_DIR/configs/shells/bash/.prompt"
 
 ### Support Angular CLI
-source ~/projects/dotfiles/configs/shells/bash/functions/angular-cli.bash
+source "$DOTFILES_DIR/configs/shells/bash/functions/angular-cli.bash"
 
 ### Support load_nvm
-source ~/projects/dotfiles/configs/shells/bash/functions/load_nvm.bash
+source "$DOTFILES_DIR/configs/shells/bash/functions/load_nvm.bash"
 
 ### Support Bash Completion for Homebrew
-source ~/projects/dotfiles/configs/shells/bash/functions/homebrew-completion.bash
+source "$DOTFILES_DIR/configs/shells/bash/functions/homebrew-completion.bash"
 
 ### Support command to shorten the prompt
-source ~/projects/dotfiles/configs/shells/bash/functions/tiny_prompt.bash
+source "$DOTFILES_DIR/configs/shells/bash/functions/tiny_prompt.bash"
 
 ### Load file .bashrc
 [ -s ~/.bashrc ] && source ~/.bashrc

--- a/configs/shells/bash/.bash_profile
+++ b/configs/shells/bash/.bash_profile
@@ -3,6 +3,10 @@
 ### Resolve the dotfiles repo root from this file's real location (handles symlinks)
 export DOTFILES_DIR="$(cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../../.." && pwd)"
 
+### Location of the private dotfiles (override via env if kept elsewhere)
+: "${DOTFILES_PRIVATE_DIR:=$HOME/projects-private/dotfiles-private}"
+export DOTFILES_PRIVATE_DIR
+
 ### Load file with variables
 source "$DOTFILES_DIR/configs/shells/__variables.sh"
 
@@ -31,7 +35,7 @@ source "$DOTFILES_DIR/configs/shells/bash/functions/tiny_prompt.bash"
 [ -s ~/.profile ] && source ~/.profile
 
 ### Load secret config files
-[ -s ~/projects-private/dotfiles-private/.profile ] && source ~/projects-private/dotfiles-private/.profile
+[ -s "$DOTFILES_PRIVATE_DIR/.profile" ] && source "$DOTFILES_PRIVATE_DIR/.profile"
 
 ### Support rbenv - Ruby Version Manager
 [ -s "/opt/homebrew/bin/rbenv" ] && eval "$(rbenv init -)"

--- a/configs/shells/bash/.prompt
+++ b/configs/shells/bash/.prompt
@@ -5,7 +5,7 @@
 # ------------------------------------------------------------------------------
 
 ### Load file with colors
-source ~/projects/dotfiles/configs/shells/__colors.sh
+source "$DOTFILES_DIR/configs/shells/__colors.sh"
 
 ### Get current state of git repo
 __parse_git_state() {

--- a/configs/shells/fish/config.fish
+++ b/configs/shells/fish/config.fish
@@ -1,6 +1,9 @@
 set -gx LANG "en_US.UTF-8"
 set -gx LC_ALL "en_US.UTF-8"
 
+### Resolve the dotfiles repo root from this file's real location (handles symlinks)
+set -gx DOTFILES_DIR (path resolve (status --current-filename)/../../../..)
+
 ### Setup default editor
 if [ "$(uname)" = 'Darwin' ]
   set -gx EDITOR code
@@ -43,7 +46,7 @@ set -gx PATH $HOME/.cargo/bin $PATH
 [ -s "/opt/homebrew/bin/rbenv" ] && status --is-interactive; and rbenv init - fish | source
 
 ### Support ripgrep
-set -gx RIPGREP_CONFIG_PATH $HOME/projects/dotfiles/configs/.ripgreprc
+set -gx RIPGREP_CONFIG_PATH $DOTFILES_DIR/configs/.ripgreprc
 
 ### Support pyenv - Python Version Manager
 [ -s "/opt/homebrew/bin/pyenv" ] && status --is-interactive; and source (pyenv init -|psub)
@@ -69,10 +72,10 @@ set -gx PATH $HOME/.lmstudio/bin $PATH
 # ------------------------------------------------------------------------------
 
 ### Load file with aliases
-bass source ~/projects/dotfiles/configs/shells/__aliases.sh
+bass source $DOTFILES_DIR/configs/shells/__aliases.sh
 
 ### Support Angular CLI
-bass source ~/projects/dotfiles/configs/shells/bash/functions/angular-cli.bash
+bass source $DOTFILES_DIR/configs/shells/bash/functions/angular-cli.bash
 
 ### Load secret config files
 [ -s "$HOME/projects-private/dotfiles-private/.profile" ] && bass source ~/projects-private/dotfiles-private/.profile

--- a/configs/shells/fish/config.fish
+++ b/configs/shells/fish/config.fish
@@ -4,6 +4,9 @@ set -gx LC_ALL "en_US.UTF-8"
 ### Resolve the dotfiles repo root from this file's real location (handles symlinks)
 set -gx DOTFILES_DIR (path resolve (status --current-filename)/../../../..)
 
+### Location of the private dotfiles (override via env if kept elsewhere)
+set -q DOTFILES_PRIVATE_DIR; or set -gx DOTFILES_PRIVATE_DIR $HOME/projects-private/dotfiles-private
+
 ### Setup default editor
 if [ "$(uname)" = 'Darwin' ]
   set -gx EDITOR code
@@ -78,7 +81,7 @@ bass source $DOTFILES_DIR/configs/shells/__aliases.sh
 bass source $DOTFILES_DIR/configs/shells/bash/functions/angular-cli.bash
 
 ### Load secret config files
-[ -s "$HOME/projects-private/dotfiles-private/.profile" ] && bass source ~/projects-private/dotfiles-private/.profile
+[ -s "$DOTFILES_PRIVATE_DIR/.profile" ] && bass source $DOTFILES_PRIVATE_DIR/.profile
 
 # ------------------------------------------------------------------------------
 

--- a/configs/shells/zsh/.zshrc
+++ b/configs/shells/zsh/.zshrc
@@ -2,26 +2,29 @@
 
 setopt EXTENDED_HISTORY
 
+### Resolve the dotfiles repo root from this file's real location (handles symlinks)
+export DOTFILES_DIR="${${(%):-%N}:A:h:h:h:h}"
+
 ### Load file with variables
-source ~/projects/dotfiles/configs/shells/__variables.sh
+source "$DOTFILES_DIR/configs/shells/__variables.sh"
 
 ### Load file with aliases
-source ~/projects/dotfiles/configs/shells/__aliases.sh
+source "$DOTFILES_DIR/configs/shells/__aliases.sh"
 
 ### Load prompt definition
-source ~/projects/dotfiles/configs/shells/zsh/.prompt
+source "$DOTFILES_DIR/configs/shells/zsh/.prompt"
 
 ### Support Angular CLI (from bash)
-source ~/projects/dotfiles/configs/shells/bash/functions/angular-cli.bash
+source "$DOTFILES_DIR/configs/shells/bash/functions/angular-cli.bash"
 
 ### Support load_nvm
-source ~/projects/dotfiles/configs/shells/zsh/functions/load_nvm.zsh
+source "$DOTFILES_DIR/configs/shells/zsh/functions/load_nvm.zsh"
 
 ### Support Zsh Completion for Homebrew
-source ~/projects/dotfiles/configs/shells/zsh/functions/homebrew-completion.zsh
+source "$DOTFILES_DIR/configs/shells/zsh/functions/homebrew-completion.zsh"
 
 ### Support timestamps for all executed commands
-source ~/projects/dotfiles/configs/shells/zsh/functions/zhist.zsh
+source "$DOTFILES_DIR/configs/shells/zsh/functions/zhist.zsh"
 
 ### Load file .profile
 [ -s ~/.profile ] && source ~/.profile

--- a/configs/shells/zsh/.zshrc
+++ b/configs/shells/zsh/.zshrc
@@ -5,6 +5,10 @@ setopt EXTENDED_HISTORY
 ### Resolve the dotfiles repo root from this file's real location (handles symlinks)
 export DOTFILES_DIR="${${(%):-%N}:A:h:h:h:h}"
 
+### Location of the private dotfiles (override via env if kept elsewhere)
+: "${DOTFILES_PRIVATE_DIR:=$HOME/projects-private/dotfiles-private}"
+export DOTFILES_PRIVATE_DIR
+
 ### Load file with variables
 source "$DOTFILES_DIR/configs/shells/__variables.sh"
 
@@ -30,7 +34,7 @@ source "$DOTFILES_DIR/configs/shells/zsh/functions/zhist.zsh"
 [ -s ~/.profile ] && source ~/.profile
 
 ### Load secret config files
-[ -s ~/projects-private/dotfiles-private/.profile ] && source ~/projects-private/dotfiles-private/.profile
+[ -s "$DOTFILES_PRIVATE_DIR/.profile" ] && source "$DOTFILES_PRIVATE_DIR/.profile"
 
 ### Support fzf
 [ -s ~/.fzf.zsh ] && source ~/.fzf.zsh


### PR DESCRIPTION
Closes #1.

Sourced config files referenced the repo by the hardcoded path `~/projects/dotfiles/`. `install.sh` already symlinks `$HOME/.zshrc`, `$HOME/.bash_profile`, `$HOME/.config/fish` etc. to files in the repo wherever it lives — but the sourced files inside were not location-independent, so cloning anywhere else broke every `source` and the gitconfig include.

## Approach

Each shell entry file (the ones symlinked from `$HOME`) resolves the repo root at startup by expanding its own symlink to the real path and walking up to the root, then exports `DOTFILES_DIR`. Every other `source`/path uses `$DOTFILES_DIR`.

| File | How `DOTFILES_DIR` is set |
| --- | --- |
| `zsh/.zshrc` | `${${(%):-%N}:A:h:h:h:h}` (native zsh, no subprocess) |
| `bash/.bash_profile` | `realpath "${BASH_SOURCE[0]}"` + `../../..` |
| `fish/config.fish` | `path resolve (status --current-filename)/../../../..` |

The gitconfig `include.path` cannot expand env vars, so it now uses a path relative to the config file (`./.gitconfig-macos`), resolved through the `~/.gitconfig` symlink.

## Private dotfiles

The shells also hardcoded the private dotfiles path (`~/projects-private/dotfiles-private`). That repo lives outside this one, so it cannot be auto-discovered — but its location is now configurable via `DOTFILES_PRIVATE_DIR` (defaults to the old path, overridable via env). Used for the `source` guards and the `dotfiles-private` alias.

The private gitconfig include stays at a fixed path (git does not expand env vars in `include.path`, and there is no symlink to resolve against); a missing include is silently ignored, so it stays safe on machines without the private repo.

## Out of scope (left intentionally)

- `$HOME/projects/claude-scripts/bin` etc. in `PATH` — separate repos.
- `pro`/`tmp` aliases — personal shortcuts.
- README `cd ~/projects/` — human instructions, not runtime paths.

## Verification

Ran fresh `zsh -i`, `bash -l`, `fish -i`: both `DOTFILES_DIR` and `DOTFILES_PRIVATE_DIR` resolve correctly in all three, `DOTFILES_PRIVATE_DIR` is overridable via env, no "no such file" errors from any `source`, `RIPGREP_CONFIG_PATH` points at an existing file, and `git config --list` is clean with the macOS-specific include loaded.

> Note: takes effect after reloading the shell (`exec $SHELL`).